### PR TITLE
Error handling for socket write

### DIFF
--- a/dist/lib/connection.js
+++ b/dist/lib/connection.js
@@ -149,13 +149,23 @@ class Connection extends typed_events_1.default {
                 that.emit('debug', "DEBUG: >>>> Send Protobuf=" + JSON.stringify(message.toJSON(), null, 2));
                 let messageLength = Buffer.from(varint.encode(encrypted.length));
                 let bytes = Buffer.concat([messageLength, encrypted]);
-                that.socket.write(bytes);
+                try {
+                    that.socket.write(bytes);
+                } catch (e) {
+                    that.emit('debug', "DEBUG: >>>> Error while writing to socket");
+                    reject();
+                }
             }
             else {
                 that.emit('debug', "DEBUG: >>>> Send Protobuf=" + JSON.stringify(message.toJSON(), null, 2));
                 let messageLength = Buffer.from(varint.encode(data.length));
                 let bytes = Buffer.concat([messageLength, data]);
-                that.socket.write(bytes);
+                try {
+                    that.socket.write(bytes);
+                } catch (e) {
+                    that.emit('debug', "DEBUG: >>>> Error while writing to socket");
+                    reject();
+                }
             }
             if (!waitForResponse) {
                 resolve(new message_1.Message(message));

--- a/dist/lib/connection.js
+++ b/dist/lib/connection.js
@@ -154,6 +154,7 @@ class Connection extends typed_events_1.default {
                 } catch (e) {
                     that.emit('debug', "DEBUG: >>>> Error while writing to socket");
                     reject();
+                    return;
                 }
             }
             else {
@@ -165,6 +166,7 @@ class Connection extends typed_events_1.default {
                 } catch (e) {
                     that.emit('debug', "DEBUG: >>>> Error while writing to socket");
                     reject();
+                    return;
                 }
             }
             if (!waitForResponse) {


### PR DESCRIPTION
A user of the Homebridge plugin **homebridge-apple-tv-remote** experienced an unhandled exception, which I traced down to the `sendProtocolMessage`. The error occurs when writing to the socket after the socket has been closed. I simply added a try-catch statement and called the unused `reject` function for the promise.

```
Error: This socket has been ended by the other party
    at Socket.writeAfterFIN [as write] (net.js:452:14)
    at /usr/local/lib/node_modules/homebridge-apple-tv-remote/node_modules/node-appletv-x/dist/lib/connection.js:152:29
    at new Promise (<anonymous>)
    at Connection.sendProtocolMessage (/usr/local/lib/node_modules/homebridge-apple-tv-remote/node_modules/node-appletv-x/dist/lib/connection.js:134:16)
    at Connection.send (/usr/local/lib/node_modules/homebridge-apple-tv-remote/node_modules/node-appletv-x/dist/lib/connection.js:130:21)
    at /usr/local/lib/node_modules/homebridge-apple-tv-remote/node_modules/node-appletv-x/dist/lib/appletv.js:182:22
```