### PR TITLE
Fix for writes to socket after connection closed

### DIFF
--- a/dist/lib/connection.js
+++ b/dist/lib/connection.js
@@ -150,7 +150,12 @@ class Connection extends typed_events_1.default {
                 let messageLength = Buffer.from(varint.encode(encrypted.length));
                 let bytes = Buffer.concat([messageLength, encrypted]);
                 try {
-                    that.socket.write(bytes);
+                    if (that.isOpen) { 
+                        that.socket.write(bytes); 
+                    } else { 
+                        reject(); 
+                        return; 
+                    }
                 } catch (e) {
                     that.emit('debug', "DEBUG: >>>> Error while writing to socket");
                     reject();
@@ -162,7 +167,12 @@ class Connection extends typed_events_1.default {
                 let messageLength = Buffer.from(varint.encode(data.length));
                 let bytes = Buffer.concat([messageLength, data]);
                 try {
-                    that.socket.write(bytes);
+                    if (that.isOpen) { 
+                        that.socket.write(bytes); 
+                    } else { 
+                        reject(); 
+                        return; 
+                    }
                 } catch (e) {
                     that.emit('debug', "DEBUG: >>>> Error while writing to socket");
                     reject();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-appletv-x",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "A Node.js library for communicating with an Apple TV",
   "homepage": "https://github.com/stickpin/node-appletv-x",
   "bugs": "https://github.com/stickpin/node-appletv-x/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-appletv-x",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "A Node.js library for communicating with an Apple TV",
   "homepage": "https://github.com/stickpin/node-appletv-x",
   "bugs": "https://github.com/stickpin/node-appletv-x/issues",
@@ -11,10 +11,6 @@
     "media remote"
   ],
   "main": "dist/index.js",
-  "scripts": {
-    "prepare": "npm run build",
-    "build": "npm run clean"
-  },
   "bin": {
     "appletv": "bin/appletv"
   },


### PR DESCRIPTION
@stickpin Sorry to bother you again. I've found a better approach to detect writes after the connection is closed, which is by checking the `isOpen` property. I also bumped the version number so you don't have to.